### PR TITLE
Fixed nomad-lab Version to 1.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
 ]
 dependencies = [
-    "nomad-lab>=1.2.0-pre",
+    "nomad-lab==1.2.0",
     "pytest",
     "typing-extensions==4.4.0",
     "structlog==22.3.0",


### PR DESCRIPTION
Fixed the version of nomad-lab to 1.2.0 for version without new basesections.