### PR TITLE
Removing dev from nomad-lab dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab>=1.3.4dev",
+    "nomad-lab>=1.3.6",
 ]
 
 [project.urls]


### PR DESCRIPTION
1.3.6 was released last week. We can bump to this one but it seems that there are 1.3.7dev releases where major changes concerning submodule migration happen. 

Our pipelines are passing with 1.3.6. We can stick with `nomad-lab>=1.3.6`. Alternatively, we wait for 1.3.7.