### PR TITLE
Add solutions category and resolve bug in combine_components

### DIFF
--- a/src/nomad_material_processing/solution/general.py
+++ b/src/nomad_material_processing/solution/general.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Union
 from nomad.datamodel.data import (
     ArchiveSection,
     EntryData,
+    EntryDataCategory,
 )
 from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
@@ -21,6 +22,7 @@ from nomad.datamodel.metainfo.basesections import (
     SystemComponent,
 )
 from nomad.metainfo import (
+    Category,
     Datetime,
     MEnum,
     Quantity,
@@ -50,6 +52,17 @@ m_package = SchemaPackage(
 configuration = config.get_plugin_entry_point(
     'nomad_material_processing.solution:schema'
 )
+
+
+class SolutionCategory(EntryDataCategory):
+    """
+    Category for entry schemas related to solutions.
+    """
+
+    m_def = Category(
+        label='Solutions',
+        categories=[EntryDataCategory],
+    )
 
 
 class MolarConcentration(ArchiveSection):
@@ -298,6 +311,7 @@ class Solution(CompositeSystem, EntryData):
 
     # TODO make the solvents, solutes, and elemental_composition subsection noneditable.
     m_def = Section(
+        categories=[SolutionCategory],
         description='A homogeneous liquid mixture composed of two or more substances.',
         a_eln=ELNAnnotation(
             properties=SectionProperties(
@@ -827,6 +841,7 @@ class SolutionPreparation(Process, EntryData):
 
     # TODO populate the instruments section based on the steps.methodology.instrument
     m_def = Section(
+        categories=[SolutionCategory],
         description='Section for describing steps of solution preparation.',
         a_eln=ELNAnnotation(
             properties=SectionProperties(


### PR DESCRIPTION
- [x] Add entry data category for solutions schemas
- When a solute component is added without any volume, the normalization runs into error:
  ```sh
  Traceback (most recent call last):
  File "/opt/venv/lib/python3.11/site-packages/nomad/normalizing/metainfo.py", line 38, in normalize_section
    normalize(archive, logger)
  File "/opt/venv/lib/python3.11/site-packages/nomad_material_processing/solution/general.py", line 514, in normalize
    self.solvents = self.combine_components(self.solvents, logger)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/nomad_material_processing/solution/general.py", line 425, in combine_components
    combined_components[comparison_key] = component.m_copy(deep=True)
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.11/site-packages/nomad/metainfo/metainfo.py", line 2394, in m_copy
    sub_sections_copy.append(sub_section.m_copy(deep=True, parent=copy))
                             ^^^^^^^^^^^^^^^^^^
  AttributeError: 'NoneType' object has no attribute 'm_copy'
  ```
  This is an error from `MSection.m_copy` method. To be resolved in nomad-lab: https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2127
