### PR TITLE
SampleHolder small changes

### DIFF
--- a/src/nomad_material_processing/vapor_deposition/general.py
+++ b/src/nomad_material_processing/vapor_deposition/general.py
@@ -31,6 +31,7 @@ from nomad.datamodel.metainfo.basesections import (
     Component,
     CompositeSystemReference,
     Entity,
+    EntityReference,
     PubChemPureSubstanceSection,
     PureSubstanceSection,
 )
@@ -118,6 +119,21 @@ class InsertReduction(Entity):
     )
 
 
+class InsertReductionPDIReference(EntityReference):
+    """
+    A section used for referencing a FilledSubstrateHolderPDI.
+    """
+
+    reference = Quantity(
+        type=InsertReduction,
+        description='Optional description of insert if used.',
+        a_eln=ELNAnnotation(
+            component='ReferenceEditQuantity',
+            label='Insert Reduction Reference',
+        ),
+    )
+
+
 class SubstrateHolderPosition(ArchiveSection):
     """
     One casing position of the substrate holder.
@@ -159,14 +175,6 @@ class SubstrateHolderPosition(ArchiveSection):
     slot_geometry = SubSection(
         section_def=Geometry,
     )
-    insert_reduction = Quantity(
-        type=InsertReduction,
-        description='Optional description of insert if used.',
-        a_eln=ELNAnnotation(
-            component='ReferenceEditQuantity',
-            label='ThinFilmStackMbe Reference',
-        ),
-    )
 
 
 class SubstrateHolder(Entity):
@@ -192,7 +200,7 @@ class SubstrateHolder(Entity):
             component=ELNComponentEnum.StringEditQuantity, label='holder_id'
         ),
     )
-    material = SubSection(section_def=PubChemPureSubstanceSection, repeats=True)
+    holder_material = SubSection(section_def=PubChemPureSubstanceSection, repeats=True)
     thickness = Quantity(
         type=float,
         unit='meter',
@@ -243,6 +251,12 @@ class FilledSubstrateHolderPosition(SubstrateHolderPosition):
     One casing position of the filled substrate holder.
     """
 
+    insert_reduction = SubSection(
+        section_def=InsertReductionPDIReference,
+        description="""
+        The Insert reduction placed in this position.
+        """,
+    )
     substrate = SubSection(
         section_def=CompositeSystemReference,
         description="""
@@ -261,7 +275,7 @@ class FilledSubstrateHolder(SubstrateHolder):
         description='A reference to an empty substrate holder.',
         a_eln=ELNAnnotation(
             component='ReferenceEditQuantity',
-            label='ThinFilmStackMbe Reference',
+            label='Empty Substrate Holder Reference',
         ),
     )
     positions = SubSection(

--- a/src/nomad_material_processing/vapor_deposition/general.py
+++ b/src/nomad_material_processing/vapor_deposition/general.py
@@ -119,7 +119,7 @@ class InsertReduction(Entity):
     )
 
 
-class InsertReductionPDIReference(EntityReference):
+class InsertReductionReference(EntityReference):
     """
     A section used for referencing a FilledSubstrateHolderPDI.
     """
@@ -252,7 +252,7 @@ class FilledSubstrateHolderPosition(SubstrateHolderPosition):
     """
 
     insert_reduction = SubSection(
-        section_def=InsertReductionPDIReference,
+        section_def=InsertReductionReference,
         description="""
         The Insert reduction placed in this position.
         """,


### PR DESCRIPTION
Few things have been changed:

- insert reduction wrapped with the usual EntityReference subclass
- material -> holder_material
- substrate_holder label
- insert_reduction reference is now included in the FilledSubstrateHolder, as it is not usually lodged in an empty one 