### PR TITLE
Added automatically generated reference docs

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -1,0 +1,1 @@
+from nomad.mkdocs import define_env  # noqa: F401

--- a/docs/reference/schemas.md
+++ b/docs/reference/schemas.md
@@ -1,0 +1,15 @@
+## General
+
+{{ metainfo_package('nomad_material_processing.general') }}
+
+## Crystal growth
+
+{{ metainfo_package('nomad_material_processing.crystal_growth') }}
+
+## Epitaxy
+
+{{ metainfo_package('nomad_material_processing.epitaxy') }}
+
+## Combinatorial
+
+{{ metainfo_package('nomad_material_processing.combinatorial') }}

--- a/docs/reference/schemas/combinatorial.md
+++ b/docs/reference/schemas/combinatorial.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.combinatorial') }}

--- a/docs/reference/schemas/crystal_growth.md
+++ b/docs/reference/schemas/crystal_growth.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.crystal_growth') }}

--- a/docs/reference/schemas/epitaxy.md
+++ b/docs/reference/schemas/epitaxy.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.epitaxy') }}

--- a/docs/reference/schemas/general.md
+++ b/docs/reference/schemas/general.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.general') }}

--- a/docs/reference/schemas/solution/general.md
+++ b/docs/reference/schemas/solution/general.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.solution.general') }}

--- a/docs/reference/schemas/vapor_deposition/cvd/general.md
+++ b/docs/reference/schemas/vapor_deposition/cvd/general.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.cvd.general') }}

--- a/docs/reference/schemas/vapor_deposition/cvd/movpe.md
+++ b/docs/reference/schemas/vapor_deposition/cvd/movpe.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.cvd.movpe') }}

--- a/docs/reference/schemas/vapor_deposition/general.md
+++ b/docs/reference/schemas/vapor_deposition/general.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.general') }}

--- a/docs/reference/schemas/vapor_deposition/pvd/general.md
+++ b/docs/reference/schemas/vapor_deposition/pvd/general.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.pvd.general') }}

--- a/docs/reference/schemas/vapor_deposition/pvd/mbe.md
+++ b/docs/reference/schemas/vapor_deposition/pvd/mbe.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.pvd.mbe') }}

--- a/docs/reference/schemas/vapor_deposition/pvd/pld.md
+++ b/docs/reference/schemas/vapor_deposition/pvd/pld.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.pvd.pld') }}

--- a/docs/reference/schemas/vapor_deposition/pvd/sputtering.md
+++ b/docs/reference/schemas/vapor_deposition/pvd/sputtering.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.pvd.sputtering') }}

--- a/docs/reference/schemas/vapor_deposition/pvd/thermal.md
+++ b/docs/reference/schemas/vapor_deposition/pvd/thermal.md
@@ -1,0 +1,1 @@
+{{ metainfo_package('nomad_material_processing.vapor_deposition.pvd.thermal') }}

--- a/docs/reference/solution.md
+++ b/docs/reference/solution.md
@@ -1,0 +1,3 @@
+## General
+
+{{ metainfo_package('nomad_material_processing.solution.general') }}

--- a/docs/reference/vapor_depostion.md
+++ b/docs/reference/vapor_depostion.md
@@ -1,0 +1,3 @@
+## General
+
+{{ metainfo_package('nomad_material_processing.vapor_deposition.general') }}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,11 +14,32 @@ nav:
     - Install this Plugin: how_to/install.md
     - Use this Plugin: how_to/use_this_plugin.md
     - Contribute to this Plugin: how_to/develop.md
-  - References: reference/references.md
+  - Reference: 
+    - Glossary: reference/references.md
+    - Schemas: 
+      - reference/schemas/general.md
+      - reference/schemas/combinatorial.md
+      - reference/schemas/epitaxy.md
+      - reference/schemas/crystal_growth.md
+      - Solution:
+        - reference/schemas/solution/general.md
+      - Vapor Deposition:
+        - reference/schemas/vapor_deposition/general.md
+        - CVD:
+          - reference/schemas/vapor_deposition/cvd/general.md
+          - reference/schemas/vapor_deposition/cvd/movpe.md
+        - PVD:
+          - reference/schemas/vapor_deposition/pvd/general.md
+          - reference/schemas/vapor_deposition/pvd/sputtering.md
+          - reference/schemas/vapor_deposition/pvd/thermal.md
+          - reference/schemas/vapor_deposition/pvd/pld.md
+          - reference/schemas/vapor_deposition/pvd/mbe.md
   - Tutorials: tutorial/tutorial.md
   - Contact: contact.md
 plugins:
  - search
+ - macros:
+    module_name: docs/main
 theme:
   name: material
   palette:


### PR DESCRIPTION
## Summary by Sourcery

Adds automatically generated reference documentation for schemas using the `mkdocs-macros` plugin.

New Features:
- Adds automatically generated reference documentation for schemas.
- Adds the `mkdocs-macros` plugin to generate the reference documentation from the metainfo packages.