### PR TITLE
Relaxed dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,11 +53,10 @@ dev = [
     "ruff",
     "structlog",
     "mkdocs", 
-    "mkdocs-material==8.1.1",
+    "mkdocs-material>=9.0",
     "pymdown-extensions",
     "mkdocs-click",
     "mkdocs-macros-plugin>=1.0",
-    "fastapi",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Relax the version constraint on mkdocs-material to allow versions greater than or equal to 9.0.