### PR TITLE
Allow prerelease versions in mkdocs deployment workflow

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and Deploy
         run: |
-          uv run --extra dev mkdocs gh-deploy --force --remote-branch gh-pages
+          uv run --extra dev --prerelease=allow mkdocs gh-deploy --force --remote-branch gh-pages


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Allow prerelease versions to be deployed.