### PR TITLE
Avoid Pydantic prerelease version

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and Deploy
         run: |
-          uv run --extra dev mkdocs gh-deploy --force --remote-branch gh-pages
+          uv run --extra dev --prerelease=allow mkdocs gh-deploy --force --remote-branch gh-pages

--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and Deploy
         run: |
-          uv run --extra dev --prerelease=allow mkdocs gh-deploy --force --remote-branch gh-pages
+          uv run --extra dev mkdocs gh-deploy --force --remote-branch gh-pages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab>=1.3.6",
+    "nomad-lab @ git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git@rebuild-type-adapter-model",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ maintainers = [
 ]
 license = { file = "LICENSE" }
 dependencies = [
-    "nomad-lab @ git+https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git@rebuild-type-adapter-model",
+    "nomad-lab >= 1.3.6",
 ]
 
 [project.urls]
@@ -57,6 +57,7 @@ dev = [
     "pymdown-extensions",
     "mkdocs-click",
     "mkdocs-macros-plugin>=1.0",
+    "pydantic>=2.0,<2.11"
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add a version constraint for Pydantic in the development dependencies to avoid using prerelease versions.