### PR TITLE
start component list from substrate

### DIFF
--- a/src/nomad_material_processing/general.py
+++ b/src/nomad_material_processing/general.py
@@ -969,11 +969,15 @@ class ThinFilmStack(CompositeSystem):
         """
         self.components = []
         if self.substrate.reference:
-            self.components.append(SystemComponent(system=self.substrate.reference))
+            self.components.append(
+                SystemComponent(
+                    name=self.substrate.name, system=self.substrate.reference
+                )
+            )
         if self.layers:
             self.components.extend(
                 [
-                    SystemComponent(system=layer.reference)
+                    SystemComponent(name=layer.name, system=layer.reference)
                     for layer in self.layers
                     if layer.reference
                 ]

--- a/src/nomad_material_processing/general.py
+++ b/src/nomad_material_processing/general.py
@@ -971,11 +971,13 @@ class ThinFilmStack(CompositeSystem):
         if self.substrate.reference:
             self.components.append(SystemComponent(system=self.substrate.reference))
         if self.layers:
-            self.components = [
-                SystemComponent(system=layer.reference)
-                for layer in self.layers
-                if layer.reference
-            ]
+            self.components.extend(
+                [
+                    SystemComponent(system=layer.reference)
+                    for layer in self.layers
+                    if layer.reference
+                ]
+            )
         super().normalize(archive, logger)
 
 

--- a/src/nomad_material_processing/general.py
+++ b/src/nomad_material_processing/general.py
@@ -968,14 +968,14 @@ class ThinFilmStack(CompositeSystem):
             logger (BoundLogger): A structlog logger.
         """
         self.components = []
+        if self.substrate.reference:
+            self.components.append(SystemComponent(system=self.substrate.reference))
         if self.layers:
             self.components = [
                 SystemComponent(system=layer.reference)
                 for layer in self.layers
                 if layer.reference
             ]
-        if self.substrate.reference:
-            self.components.append(SystemComponent(system=self.substrate.reference))
         super().normalize(archive, logger)
 
 


### PR DESCRIPTION
I think we need to include the substrate as the first element of the list

## Summary by Sourcery

Enhancements:
- Reorders the component list to include the substrate as the first element.