### PR TITLE
Use env from nomad-docs

### DIFF
--- a/docs/main.py
+++ b/docs/main.py
@@ -1,1 +1,1 @@
-from nomad.mkdocs import define_env  # noqa: F401
+from nomad_docs import define_env  # noqa: F401

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,13 +51,13 @@ dev = [
     "pytest",
     "ruff",
     "structlog",
+    "nomad-docs>=0.1.3",
     "mkdocs",
     "mkdocs-material>=9.0",
     "pymdown-extensions",
     "mkdocs-click",
     "mkdocs-macros-plugin>=1.0",
     "pydantic>=2.0,<2.11",
-    "nomad-docs",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,13 @@ dev = [
     "pytest",
     "ruff",
     "structlog",
-    "mkdocs", 
+    "mkdocs",
     "mkdocs-material>=9.0",
     "pymdown-extensions",
     "mkdocs-click",
     "mkdocs-macros-plugin>=1.0",
-    "pydantic>=2.0,<2.11"
+    "pydantic>=2.0,<2.11",
+    "nomad-docs",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ select = [
 
 ignore = [
     "F403", # 'from module import *' used; unable to detect undefined names
+    "PLC0415", # `import` should be at the top-level of a file
 ]
 
 fixable = ["ALL"]


### PR DESCRIPTION
- [x] As the `env` containing the macros for mkdocs is now moved to `nomad-docs`, update the import

## Summary by Sourcery

Use the macros environment provided by the nomad-docs package for mkdocs and update project dependencies accordingly.

Enhancements:
- Switch the mkdocs macros env import to come from the nomad-docs package

Build:
- Add nomad-docs as a dependency in pyproject.toml