### PR TITLE
Disallow pre-release for uv

### DIFF
--- a/.github/workflows/mkdocs-deploy.yml
+++ b/.github/workflows/mkdocs-deploy.yml
@@ -31,4 +31,4 @@ jobs:
 
       - name: Build and Deploy
         run: |
-          uv run --extra dev --prerelease=allow mkdocs gh-deploy --force --remote-branch gh-pages
+          uv run --extra dev mkdocs gh-deploy --force --remote-branch gh-pages


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove the "--prerelease=allow" flag from the uv run command in the mkdocs-deploy GitHub Actions workflow