### PR TITLE
initial plugin metadata extraction

### DIFF
--- a/.metadata/nomad_plugin_metadata.auto.yaml
+++ b/.metadata/nomad_plugin_metadata.auto.yaml
@@ -1,0 +1,186 @@
+id: nomad-material-processing
+metadata_schema_version: 1.0.0
+name: nomad-material-processing
+description: A plugin for NOMAD containing base sections for material processing.
+license: LICENSE
+upstream_repository: https://github.com/FAIRmat-NFDI/nomad-material-processing
+documentation: https://fairmat-nfdi.github.io/nomad-material-processing/
+homepage: https://github.com/FAIRmat-NFDI/nomad-material-processing
+issue_tracker: https://github.com/FAIRmat-NFDI/nomad-material-processing/issues
+maintainers:
+- name: FAIRmat
+  email: fairmat@physik.hu-berlin.de
+authors:
+- name: Andrea Albino
+- name: "Sebastian Br\xFCckner"
+- name: "Michael G\xF6tte"
+- name: Ahmed Ilyas
+- name: Sarthak Kapoor
+- name: "Jos\xE9 A. M\xE1rquez"
+- name: "Hampus N\xE4sstr\xF6m"
+- name: Markus Scheidgen
+entry_points:
+- id: nomad.plugin:general_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: general_schema
+  python_object: nomad_material_processing:schema
+  capability_type: schema
+- id: nomad.plugin:solution_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: solution_schema
+  python_object: nomad_material_processing.solution:schema
+  capability_type: schema
+- id: nomad.plugin:vd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: vd_schema
+  python_object: nomad_material_processing.vapor_deposition:schema
+  capability_type: schema
+- id: nomad.plugin:cvd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: cvd_schema
+  python_object: nomad_material_processing.vapor_deposition.cvd:schema
+  capability_type: schema
+- id: nomad.plugin:movpe_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: movpe_schema
+  python_object: nomad_material_processing.vapor_deposition.cvd:movpe_schema
+  capability_type: schema
+- id: nomad.plugin:pvd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: pvd_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:schema
+  capability_type: schema
+- id: nomad.plugin:mbe_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: mbe_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:mbe_schema
+  capability_type: schema
+- id: nomad.plugin:pld_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: pld_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:pld_schema
+  capability_type: schema
+- id: nomad.plugin:sputtering_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: sputtering_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:sputtering_schema
+  capability_type: schema
+- id: nomad.plugin:thermal_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: thermal_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:thermal_schema
+  capability_type: schema
+capabilities:
+- id: general_schema
+  capability_type: schema
+  title: General Schema
+  summary: "Schema package containing basic classes used\n    in the nomad_material_processing\
+    \ plugin."
+- id: solution_schema
+  capability_type: schema
+  title: Solution Schema
+  summary: Schema package containing classes for liquid solutions.
+- id: vd_schema
+  capability_type: schema
+  title: General Vapor Deposition Schema
+  summary: "Schema package containing basic classes used\n    in the vapor_deposition\
+    \ submodule."
+- id: cvd_schema
+  capability_type: schema
+  title: CVD Schema
+  summary: Schema package for general CVD techniques.
+- id: movpe_schema
+  capability_type: schema
+  title: MOVPE Schema
+  summary: Schema package for MOVPE techniques.
+- id: pvd_schema
+  capability_type: schema
+  title: General PVD Schema
+  summary: "Schema package containing basic classes used\n    in the vapor_deposition\
+    \ submodule."
+- id: mbe_schema
+  capability_type: schema
+  title: Mbe Schema
+  summary: "Schema package containing basic classes used\n    in the MBE submodule."
+- id: pld_schema
+  capability_type: schema
+  title: Pld Schema
+  summary: "Schema package containing basic classes used\n    in the PLD submodule."
+- id: sputtering_schema
+  capability_type: schema
+  title: Sputtering Schema
+  summary: "Schema package containing basic classes used\n    in the sputtering submodule."
+- id: thermal_schema
+  capability_type: schema
+  title: Thermal Schema
+  summary: "Schema package containing basic classes used\n    in the thermal submodule."
+schema_dependencies:
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '>= 1.3.14'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pytest
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: structlog
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: nomad-docs
+  version_range: '>=0.1.3'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material
+  version_range: '>=9.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pymdown-extensions
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-click
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-macros-plugin
+  version_range: '>=1.0'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:50:31.884588+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:50:31.884624+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:50:31.884639+00:00'
+  generator_version: 0.1.0
+stars: 11
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2023-08-15T09:04:41Z'
+last_updated: '2025-08-11T13:23:35Z'
+archived: false

--- a/.metadata/nomad_plugin_metadata.manual.yaml
+++ b/.metadata/nomad_plugin_metadata.manual.yaml
@@ -1,0 +1,84 @@
+# Maintainer-owned metadata overrides and manual additions.
+# This file is never machine-overwritten after creation.
+# Use null/empty values as placeholders; only non-empty values override auto output.
+# list[str] domain/topic tags (e.g. "simulations", "spectroscopy")
+subject:
+  - synthesis
+  - material-processing
+  - thin-films
+  - vapor-deposition
+  - workflows
+# enum {alpha, beta, stable, archived}
+maturity: stable
+# str, e.g. "main"
+repository_default_branch: main
+
+# Deployment flags.
+deployment:
+  # boolean
+  on_central: true
+  # boolean
+  on_example_oasis: null
+  # boolean
+  on_pypi: true
+  # str (PyPI package name)
+  pypi_package: nomad-material-processing
+
+# Suggested usages for registry filtering/discovery.
+suggested_usages:
+  -
+    # str (stable ID slug), e.g. "parse-xrd-patterns"
+    id: model-vapor-deposition-processes
+    # str
+    title: Model vapor deposition processing metadata
+    # str (what user wants to do), e.g. "Import and parse raw files"
+    user_intent: Structure CVD and PVD process metadata in NOMAD entries
+    # enum {simulations, measurements, synthesis, cross-domain, workflow, infrastructure}
+    domain_category: synthesis
+    # str, e.g. "XRD", "DFT"
+    technique: vapor-deposition
+    # str, e.g. "beginner", "expert"
+    audience: intermediate
+    # enum {alpha, beta, stable, archived}
+    maturity: stable
+    # list[str]
+    tags: [cvd, pvd, mbe, pld, sputtering]
+  -
+    # str (stable ID slug), e.g. "parse-xrd-patterns"
+    id: harmonize-processing-workflows
+    # str
+    title: Harmonize material processing workflows
+    # str (what user wants to do), e.g. "Import and parse raw files"
+    user_intent: Reuse shared schema sections across material processing plugins
+    # enum {simulations, measurements, synthesis, cross-domain, workflow, infrastructure}
+    domain_category: workflow
+    # str, e.g. "XRD", "DFT"
+    technique: schema-harmonization
+    # str, e.g. "beginner", "expert"
+    audience: advanced
+    # enum {alpha, beta, stable, archived}
+    maturity: stable
+    # list[str]
+    tags: [schema, interoperability, processing]
+
+# Optional file format metadata enrichments.
+file_format_support:
+  -
+    # str (stable ID), e.g. "csv"
+    id: null
+    # str display label, e.g. ".csv"
+    label: null
+    # str capability reference (links to capabilities[].id), e.g. "vasp_parser"
+    capability_id: null
+    # str producer/code family for ambiguous extensions, e.g. "vasp", "quantumespresso"
+    producer: null
+    # list[str] extensions including dot, e.g. [".csv", ".txt"]
+    extensions: []
+    # list[str], e.g. ["text/csv"]
+    mime_types: []
+    # str, e.g. "CIF", "NeXus"
+    standard: null
+    # str, instrument or context label
+    instrument_context: null
+    # str free text notes
+    notes: null

--- a/.metadata/plugin-metadata.override-report.yaml
+++ b/.metadata/plugin-metadata.override-report.yaml
@@ -1,0 +1,4 @@
+summary:
+  overridden_field_count: 0
+  manual_precedence: true
+overridden_fields: []

--- a/nomad_plugin_metadata.yaml
+++ b/nomad_plugin_metadata.yaml
@@ -1,0 +1,223 @@
+id: nomad-material-processing
+metadata_schema_version: 1.0.0
+name: nomad-material-processing
+description: A plugin for NOMAD containing base sections for material processing.
+license: LICENSE
+upstream_repository: https://github.com/FAIRmat-NFDI/nomad-material-processing
+documentation: https://fairmat-nfdi.github.io/nomad-material-processing/
+homepage: https://github.com/FAIRmat-NFDI/nomad-material-processing
+issue_tracker: https://github.com/FAIRmat-NFDI/nomad-material-processing/issues
+maintainers:
+- name: FAIRmat
+  email: fairmat@physik.hu-berlin.de
+authors:
+- name: Andrea Albino
+- name: "Sebastian Br\xFCckner"
+- name: "Michael G\xF6tte"
+- name: Ahmed Ilyas
+- name: Sarthak Kapoor
+- name: "Jos\xE9 A. M\xE1rquez"
+- name: "Hampus N\xE4sstr\xF6m"
+- name: Markus Scheidgen
+entry_points:
+- id: nomad.plugin:general_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: general_schema
+  python_object: nomad_material_processing:schema
+  capability_type: schema
+- id: nomad.plugin:solution_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: solution_schema
+  python_object: nomad_material_processing.solution:schema
+  capability_type: schema
+- id: nomad.plugin:vd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: vd_schema
+  python_object: nomad_material_processing.vapor_deposition:schema
+  capability_type: schema
+- id: nomad.plugin:cvd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: cvd_schema
+  python_object: nomad_material_processing.vapor_deposition.cvd:schema
+  capability_type: schema
+- id: nomad.plugin:movpe_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: movpe_schema
+  python_object: nomad_material_processing.vapor_deposition.cvd:movpe_schema
+  capability_type: schema
+- id: nomad.plugin:pvd_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: pvd_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:schema
+  capability_type: schema
+- id: nomad.plugin:mbe_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: mbe_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:mbe_schema
+  capability_type: schema
+- id: nomad.plugin:pld_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: pld_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:pld_schema
+  capability_type: schema
+- id: nomad.plugin:sputtering_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: sputtering_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:sputtering_schema
+  capability_type: schema
+- id: nomad.plugin:thermal_schema
+  entry_point_group: nomad.plugin
+  entry_point_name: thermal_schema
+  python_object: nomad_material_processing.vapor_deposition.pvd:thermal_schema
+  capability_type: schema
+capabilities:
+- id: general_schema
+  capability_type: schema
+  title: General Schema
+  summary: "Schema package containing basic classes used\n    in the nomad_material_processing\
+    \ plugin."
+- id: solution_schema
+  capability_type: schema
+  title: Solution Schema
+  summary: Schema package containing classes for liquid solutions.
+- id: vd_schema
+  capability_type: schema
+  title: General Vapor Deposition Schema
+  summary: "Schema package containing basic classes used\n    in the vapor_deposition\
+    \ submodule."
+- id: cvd_schema
+  capability_type: schema
+  title: CVD Schema
+  summary: Schema package for general CVD techniques.
+- id: movpe_schema
+  capability_type: schema
+  title: MOVPE Schema
+  summary: Schema package for MOVPE techniques.
+- id: pvd_schema
+  capability_type: schema
+  title: General PVD Schema
+  summary: "Schema package containing basic classes used\n    in the vapor_deposition\
+    \ submodule."
+- id: mbe_schema
+  capability_type: schema
+  title: Mbe Schema
+  summary: "Schema package containing basic classes used\n    in the MBE submodule."
+- id: pld_schema
+  capability_type: schema
+  title: Pld Schema
+  summary: "Schema package containing basic classes used\n    in the PLD submodule."
+- id: sputtering_schema
+  capability_type: schema
+  title: Sputtering Schema
+  summary: "Schema package containing basic classes used\n    in the sputtering submodule."
+- id: thermal_schema
+  capability_type: schema
+  title: Thermal Schema
+  summary: "Schema package containing basic classes used\n    in the thermal submodule."
+schema_dependencies:
+- dependency_type: python_package
+  package_name: nomad-lab
+  version_range: '>= 1.3.14'
+  optional: false
+  purpose: runtime
+- dependency_type: python_package
+  package_name: pytest
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: ruff
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: structlog
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: nomad-docs
+  version_range: '>=0.1.3'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-material
+  version_range: '>=9.0'
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: pymdown-extensions
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-click
+  version_range: ''
+  optional: true
+  purpose: optional
+- dependency_type: python_package
+  package_name: mkdocs-macros-plugin
+  version_range: '>=1.0'
+  optional: true
+  purpose: optional
+metadata_provenance:
+- source: pyproject
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:50:31.884588+00:00'
+  generator_version: 0.1.0
+- source: plugin_entry_points
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:50:31.884624+00:00'
+  generator_version: 0.1.0
+- source: citation_cff
+  extraction_method: deterministic
+  generated_at: '2026-03-19T14:50:31.884639+00:00'
+  generator_version: 0.1.0
+stars: 11
+owner: FAIRmat-NFDI
+owner_type: Organization
+created: '2023-08-15T09:04:41Z'
+last_updated: '2025-08-11T13:23:35Z'
+archived: false
+subject:
+- synthesis
+- material-processing
+- thin-films
+- vapor-deposition
+- workflows
+maturity: stable
+repository_default_branch: main
+deployment:
+  on_central: true
+  on_pypi: true
+  pypi_package: nomad-material-processing
+suggested_usages:
+- id: model-vapor-deposition-processes
+  title: Model vapor deposition processing metadata
+  user_intent: Structure CVD and PVD process metadata in NOMAD entries
+  domain_category: synthesis
+  technique: vapor-deposition
+  audience: intermediate
+  maturity: stable
+  tags:
+  - cvd
+  - pvd
+  - mbe
+  - pld
+  - sputtering
+- id: harmonize-processing-workflows
+  title: Harmonize material processing workflows
+  user_intent: Reuse shared schema sections across material processing plugins
+  domain_category: workflow
+  technique: schema-harmonization
+  audience: advanced
+  maturity: stable
+  tags:
+  - schema
+  - interoperability
+  - processing


### PR DESCRIPTION
## Summary

This PR adds the first metadata extraction for `nomad-simulation-parsers` using the `nomad-plugin-metadata` pipeline.

## What to review

Please review **`nomad_plugin_metadata.yaml`**.  
This is the canonical, merged file intended for querying/registry usage.

## How files work

- `.metadata/nomad_plugin_metadata.auto.yaml`  
  Machine-generated metadata from package/plugin introspection.
- `.metadata/nomad_plugin_metadata.manual.yaml`  
  Maintainer-owned manual curation/overrides (not machine-overwritten).
- `nomad_plugin_metadata.yaml`  
  Final merged output (auto + manual; manual non-empty values take precedence).
- `.metadata/plugin-metadata.override-report.yaml`  
  Report of conflicts where manual overrides auto.

## Goal of this PR

Initial extraction pass for developer feedback before broader rollout:
- verify extracted parser/file-format metadata
- identify missing/incorrect fields
- align expected manual curation scope

## References

- `nomad-plugins-metadata`: https://github.com/FAIRmat-NFDI/nomad-plugins-metadata, https://fairmat-nfdi.github.io/nomad-plugins-metadata/reference/schema_reference.html#full-schema-shaped-yaml-template
- `datatractor`: https://github.com/datatractor
